### PR TITLE
esx:spawnVehicle using Player Heading

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -243,10 +243,11 @@ AddEventHandler('esx:spawnVehicle', function(vehicle)
 	local model = (type(vehicle) == 'number' and vehicle or GetHashKey(vehicle))
 
 	if IsModelInCdimage(model) then
-		local playerPed = PlayerPedId()
-		local coords    = GetEntityCoords(playerPed)
+		local playerPed 	= PlayerPedId()
+		local coords    	= GetEntityCoords(playerPed)
+		local playerHeading = GetEntityHeading(playerPed)
 
-		ESX.Game.SpawnVehicle(model, coords, 90.0, function(vehicle)
+		ESX.Game.SpawnVehicle(model, coords, playerHeading, function(vehicle)
 			TaskWarpPedIntoVehicle(playerPed, vehicle, -1)
 		end)
 	else


### PR DESCRIPTION
Updated esx:spawnVehicle to use the players heading as opposed to the default 90.0 degree angle